### PR TITLE
Update projects to .NET 9

### DIFF
--- a/SnaffCore/SnaffCore.csproj
+++ b/SnaffCore/SnaffCore.csproj
@@ -1,98 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B118802D-2E46-4E41-AAC7-9EE890268F8B}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SnaffCore</RootNamespace>
-    <AssemblyName>SnaffCore</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.DirectoryServices" />
-    <Reference Include="System.DirectoryServices.Protocols" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.XML" />
+    <PackageReference Include="Nett.Coma" Version="0.15.0" />
+    <PackageReference Include="System.DirectoryServices" Version="7.0.0" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="7.0.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ActiveDirectory\DfsFinder.cs" />
-    <Compile Include="ActiveDirectory\DirectorySearch.cs" />
-    <Compile Include="ActiveDirectory\Extensions.cs" />
-    <Compile Include="ActiveDirectory\Helpers.cs" />
-    <Compile Include="ActiveDirectory\LdapTypeEnum.cs" />
-    <Compile Include="Classifiers\ArchiveClassifier.cs" />
-    <Compile Include="Classifiers\Certificate.cs" />
-    <Compile Include="Classifiers\EffectiveAccess.cs" />
-    <Compile Include="Classifiers\FileResult.cs" />
-    <Compile Include="Classifiers\PostMatchClassifier.cs" />
-    <Compile Include="Classifiers\TextClassifier.cs" />
-    <Compile Include="Classifiers\ContentClassifier.cs" />
-    <Compile Include="Classifiers\DirClassifier.cs" />
-    <Compile Include="Classifiers\FileClassifier.cs" />
-    <Compile Include="Classifiers\ShareClassifier.cs" />
-    <Compile Include="ActiveDirectory\AdData.cs" />
-    <Compile Include="Concurrency\BlockingMq.cs" />
-    <Compile Include="Concurrency\BlockingTaskScheduler.cs" />
-    <Compile Include="Concurrency\SnafflerMessage.cs" />
-    <Compile Include="Concurrency\SnafflerMessageType.cs" />
-    <Compile Include="Config\ClassifierOptions.cs" />
-    <Compile Include="Config\Options.cs" />
-    <Compile Include="Classifiers\ClassifierRule.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ShareFind\ShareFinder.cs" />
-    <Compile Include="FileScan\FileScanner.cs" />
-    <Compile Include="TreeWalk\TreeWalker.cs" />
-    <Compile Include="SnaffCon.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Nett.Coma">
-      <Version>0.15.0</Version>
-    </PackageReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/SnaffCore/UltraSnaffCore.csproj
+++ b/SnaffCore/UltraSnaffCore.csproj
@@ -1,104 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B118802D-2E46-4E41-AAC7-9EE890268F8B}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SnaffCore</RootNamespace>
-    <AssemblyName>SnaffCore</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;ULTRASNAFFLER</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;ULTRASNAFFLER</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;ULTRASNAFFLER</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE;ULTRASNAFFLER</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <DefineConstants>ULTRASNAFFLER</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.DirectoryServices" />
-    <Reference Include="System.DirectoryServices.Protocols" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.XML" />
+    <PackageReference Include="Nett.Coma" Version="0.15.0" />
+    <PackageReference Include="SharpCompress" Version="0.24.0" />
+    <PackageReference Include="Toxy" Version="1.6.1.1" />
+    <PackageReference Include="System.DirectoryServices" Version="7.0.0" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="7.0.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ActiveDirectory\AdData.cs" />
-    <Compile Include="ActiveDirectory\DfsFinder.cs" />
-    <Compile Include="ActiveDirectory\DirectorySearch.cs" />
-    <Compile Include="ActiveDirectory\Extensions.cs" />
-    <Compile Include="ActiveDirectory\Helpers.cs" />
-    <Compile Include="ActiveDirectory\LdapTypeEnum.cs" />
-    <Compile Include="Classifiers\ArchiveClassifier.cs" />
-    <Compile Include="Classifiers\Certificate.cs" />
-    <Compile Include="Classifiers\EffectiveAccess.cs" />
-    <Compile Include="Classifiers\FileResult.cs" />
-    <Compile Include="Classifiers\PostMatchClassifier.cs" />
-    <Compile Include="Classifiers\TextClassifier.cs" />
-    <Compile Include="Classifiers\ContentClassifier.cs" />
-    <Compile Include="Classifiers\DirClassifier.cs" />
-    <Compile Include="Classifiers\FileClassifier.cs" />
-    <Compile Include="Classifiers\ShareClassifier.cs" />
-    <Compile Include="Concurrency\BlockingMq.cs" />
-    <Compile Include="Concurrency\BlockingTaskScheduler.cs" />
-    <Compile Include="Concurrency\SnafflerMessage.cs" />
-    <Compile Include="Concurrency\SnafflerMessageType.cs" />
-    <Compile Include="Config\ClassifierOptions.cs" />
-    <Compile Include="Config\Options.cs" />
-    <Compile Include="Classifiers\ClassifierRule.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ShareFind\ShareFinder.cs" />
-    <Compile Include="FileScan\FileScanner.cs" />
-    <Compile Include="TreeWalk\TreeWalker.cs" />
-    <Compile Include="SnaffCon.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Nett.Coma">
-      <Version>0.15.0</Version>
-    </PackageReference>
-    <PackageReference Include="SharpCompress">
-      <Version>0.24.0</Version>
-    </PackageReference>
-    <PackageReference Include="Toxy">
-      <Version>1.6.1.1</Version>
-    </PackageReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Snaffler/Snaffler.csproj
+++ b/Snaffler/Snaffler.csproj
@@ -1,115 +1,22 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{2AA060B4-DE88-4D2A-A26A-760C1CEFEC3E}</ProjectGuid>
     <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Snaffler</RootNamespace>
     <AssemblyName>Snaffler</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject>
-    </StartupObject>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Xml" />
+    <ProjectReference Include="..\SnaffCore\SnaffCore.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Config.cs" />
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="RuleSet.cs" />
-    <Compile Include="Snaffler.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SnaffleRunner.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\SnaffCore\SnaffCore.csproj">
-      <Project>{b118802d-2e46-4e41-aac7-9ee890268f8b}</Project>
-      <Name>SnaffCore</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
     <EmbeddedResource Include="SnaffRules\DefaultRules\**\*.toml" />
     <None Include="SnaffRules\DefaultRules\ShareRules\Keep\KeepSCCMShares.toml" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
+    <PackageReference Include="CommandLineArgumentsParser" Version="3.0.22" />
+    <PackageReference Include="dnMerge" Version="0.5.15" PrivateAssets="all" />
+    <PackageReference Include="Nett" Version="0.15.0" />
+    <PackageReference Include="NLog" Version="4.7.15" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="CommandLineArgumentsParser">
-      <Version>3.0.22</Version>
-    </PackageReference>
-    <PackageReference Include="dnMerge">
-      <Version>0.5.15</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Nett">
-      <Version>0.15.0</Version>
-    </PackageReference>
-    <PackageReference Include="NLog">
-      <Version>4.7.15</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
## Summary
- migrate Snaffler projects to SDK-style csproj files
- target `net9.0` for all projects
- add required `System.DirectoryServices` packages

## Testing
- `dotnet build Snaffler.sln`
- `dotnet run --project Snaffler/Snaffler.csproj -- --help` *(fails: Windows APIs not supported)*

------
https://chatgpt.com/codex/tasks/task_e_684316612044832fae22b5c0fb366c3b