### PR TITLE
Modernize queue processing with async channels

### DIFF
--- a/Snaffler/Snaffler.cs
+++ b/Snaffler/Snaffler.cs
@@ -1,13 +1,14 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Snaffler
 {
     public static class Snaffler
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
             SnaffleRunner runner = new SnaffleRunner();
-            runner.Run(args);
+            await runner.RunAsync(args);
             Console.WriteLine("I snaffled 'til the snafflin was done.");
         }
     }


### PR DESCRIPTION
## Summary
- switch the message queue to use `Channel` for async support
- add async `RunAsync` and `Main` methods
- consume queue asynchronously with `HandleOutputAsync`

## Testing
- `dotnet build Snaffler.sln`

------
https://chatgpt.com/codex/tasks/task_e_6843219263b4832f93313785b4a617ed