### PR TITLE
Restore resources and add cross-targeting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ publish/
 # Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
+!Snaffler/Properties/PublishProfiles/*.pubxml
 *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to

--- a/SnaffCore/Config/CsTomlStub.cs
+++ b/SnaffCore/Config/CsTomlStub.cs
@@ -1,0 +1,11 @@
+#if NETFRAMEWORK
+namespace CsToml
+{
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct)]
+    public sealed class TomlSerializedObjectAttribute : System.Attribute { }
+
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
+    public sealed class TomlValueOnSerializedAttribute : System.Attribute { }
+}
+#endif
+

--- a/SnaffCore/SnaffCore.csproj
+++ b/SnaffCore/SnaffCore.csproj
@@ -1,13 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net451</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PublishAot>true</PublishAot>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PackageReference Include="CsToml" Version="1.6.5" />
     <PackageReference Include="CsToml.Generator" Version="1.6.5" />
     <PackageReference Include="System.DirectoryServices" Version="7.0.0" />
     <PackageReference Include="System.DirectoryServices.Protocols" Version="7.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <PackageReference Include="Nett.Coma" Version="0.15.0" />
+    <Reference Include="System.DirectoryServices" />
+    <Reference Include="System.DirectoryServices.Protocols" />
   </ItemGroup>
 </Project>

--- a/SnaffCore/UltraSnaffCore.csproj
+++ b/SnaffCore/UltraSnaffCore.csproj
@@ -1,16 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net451</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>ULTRASNAFFLER</DefineConstants>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PublishAot>true</PublishAot>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PackageReference Include="CsToml" Version="1.6.5" />
     <PackageReference Include="CsToml.Generator" Version="1.6.5" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="Toxy" Version="1.6.1.1" />
     <PackageReference Include="System.DirectoryServices" Version="7.0.0" />
     <PackageReference Include="System.DirectoryServices.Protocols" Version="7.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <PackageReference Include="Nett.Coma" Version="0.15.0" />
+    <PackageReference Include="SharpCompress" Version="0.24.0" />
+    <PackageReference Include="Toxy" Version="1.6.1.1" />
+    <Reference Include="System.DirectoryServices" />
+    <Reference Include="System.DirectoryServices.Protocols" />
   </ItemGroup>
 </Project>

--- a/Snaffler/FileCompat.cs
+++ b/Snaffler/FileCompat.cs
@@ -1,0 +1,45 @@
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Snaffler
+{
+    internal static class FileCompat
+    {
+        public static Task<string[]> ReadAllLinesAsync(string path)
+        {
+#if NETFRAMEWORK
+            return Task.FromResult(File.ReadAllLines(path));
+#else
+            return File.ReadAllLinesAsync(path);
+#endif
+        }
+
+        public static Task<string> ReadAllTextAsync(string path)
+        {
+#if NETFRAMEWORK
+            return Task.FromResult(File.ReadAllText(path));
+#else
+            return File.ReadAllTextAsync(path);
+#endif
+        }
+
+        public static Task<byte[]> ReadAllBytesAsync(string path)
+        {
+#if NETFRAMEWORK
+            return Task.FromResult(File.ReadAllBytes(path));
+#else
+            return File.ReadAllBytesAsync(path);
+#endif
+        }
+
+        public static Task WriteAllBytesAsync(string path, byte[] bytes)
+        {
+#if NETFRAMEWORK
+            File.WriteAllBytes(path, bytes);
+            return Task.FromResult(0);
+#else
+            return File.WriteAllBytesAsync(path, bytes);
+#endif
+        }
+    }
+}

--- a/Snaffler/FodyWeavers.xml
+++ b/Snaffler/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <Costura CreateTemporaryAssemblies="false" />
+</Weavers>

--- a/Snaffler/IsExternalInit.cs
+++ b/Snaffler/IsExternalInit.cs
@@ -1,0 +1,6 @@
+#if NETFRAMEWORK
+namespace System.Runtime.CompilerServices
+{
+    public static class IsExternalInit { }
+}
+#endif

--- a/Snaffler/Properties/PublishProfiles/net451.pubxml
+++ b/Snaffler/Properties/PublishProfiles/net451.pubxml
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net451</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <Configuration>Release</Configuration>
+    <SelfContained>false</SelfContained>
+  </PropertyGroup>
+  <Target Name="CopyMerged" AfterTargets="Publish">
+    <Copy SourceFiles="$(OutputPath)$(AssemblyName).exe" DestinationFolder="$(PublishDir)" />
+  </Target>
+</Project>

--- a/Snaffler/Properties/PublishProfiles/net9.pubxml
+++ b/Snaffler/Properties/PublishProfiles/net9.pubxml
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <Configuration>Release</Configuration>
+  </PropertyGroup>
+</Project>

--- a/Snaffler/Snaffler.csproj
+++ b/Snaffler/Snaffler.csproj
@@ -1,11 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net451</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Snaffler</RootNamespace>
     <AssemblyName>Snaffler</AssemblyName>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PublishAot>true</PublishAot>
+    <FodyDisable>true</FodyDisable>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <FodyEnable>true</FodyEnable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SnaffCore\SnaffCore.csproj" />
@@ -16,8 +23,17 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineArgumentsParser" Version="3.0.22" />
-    <PackageReference Include="dnMerge" Version="0.5.15" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PackageReference Include="CsToml" Version="1.6.5" />
     <PackageReference Include="CsToml.Generator" Version="1.6.5" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <PackageReference Include="Nett" Version="0.15.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Fody" Version="6.7.0" PrivateAssets="all" />
+    <PackageReference Include="Costura.Fody" Version="5.7.0" PrivateAssets="all" />
+    <Reference Include="System.DirectoryServices" />
+    <Reference Include="System.DirectoryServices.Protocols" />
   </ItemGroup>
 </Project>

--- a/Snaffler/TomlCompat.cs
+++ b/Snaffler/TomlCompat.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading.Tasks;
+using SnaffCore.Config;
+#if NETFRAMEWORK
+using Nett;
+#else
+using CsToml;
+#endif
+
+namespace Snaffler
+{
+    internal static class TomlCompat
+    {
+#if NETFRAMEWORK
+        private static readonly TomlSettings Settings = TomlSettings.Create(cfg => cfg
+            .ConfigureType<LogLevel>(tc => tc.WithConversionFor<TomlString>(conv => conv
+                .FromToml(s => (LogLevel)Enum.Parse(typeof(LogLevel), s.Value, ignoreCase: true))
+                .ToToml(e => e.ToString()))));
+
+        public static Task WriteFileAsync(Options options, string path)
+        {
+            Toml.WriteFile(options, path, Settings);
+            return Task.FromResult(0);
+        }
+
+        public static Task<Options> ReadFileAsync(string path)
+        {
+            return Task.FromResult(Toml.ReadFile<Options>(path, Settings));
+        }
+
+        public static RuleSet ReadString(string content)
+        {
+            return Toml.ReadString<RuleSet>(content, Settings);
+        }
+#else
+        public static async Task WriteFileAsync(Options options, string path)
+        {
+            using var result = CsTomlSerializer.Serialize(options);
+            await FileCompat.WriteAllBytesAsync(path, result.ByteSpan.ToArray());
+        }
+
+        public static async Task<Options> ReadFileAsync(string path)
+        {
+            return CsTomlSerializer.Deserialize<Options>(await FileCompat.ReadAllBytesAsync(path));
+        }
+
+        public static RuleSet ReadString(string content)
+        {
+            return CsTomlSerializer.Deserialize<RuleSet>(System.Text.Encoding.UTF8.GetBytes(content));
+        }
+#endif
+    }
+}

--- a/publish.bat
+++ b/publish.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+set DOTNET_FLAGS=-c Release
+
+dotnet publish Snaffler\Snaffler.csproj %DOTNET_FLAGS% -f net451 -p:PublishProfile=net451
+
+dotnet publish Snaffler\Snaffler.csproj %DOTNET_FLAGS% -f net9.0 -p:PublishProfile=net9
+endlocal
+


### PR DESCRIPTION
## Summary
- restore previously removed sample resources
- multi-target both net451 and net9.0
- configure Fody/Costura for single-file .NET Framework builds
- add FileCompat/TomlCompat helpers for cross-version support
- provide publish profiles and helper script
- target Windows with the .NET 9 publish profile and supply a Windows batch script
- drop the README notes and allow PublishProfiles in Git

## Testing
- `dotnet build Snaffler.sln -c Release`
- `dotnet publish Snaffler/Snaffler.csproj -c Release -f net451`
- `dotnet publish Snaffler/Snaffler.csproj -c Release -f net9.0`
- `dotnet publish Snaffler/Snaffler.csproj -c Release -f net9.0 -p:PublishProfile=net9` *(fails: cross-OS native compilation not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6846447d8304832f9a48a3316d99ed20